### PR TITLE
Objet physique support d’un contenu textuel (objet linguistique)

### DIFF
--- a/data/exhibit/exhibit-0002.ttl
+++ b/data/exhibit/exhibit-0002.ttl
@@ -11,12 +11,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 exhib:exhibit0002
     rdf:type                    crm:E22_Human-Made_Object ;
     rdfs:label                  "Titre de l’exposition"@fr ;
-    rdfs:comment                "Trouver un moyen de transcrire le contenu textuel de l’exhibit (ZR)"@fr ;
+    rdfs:comment                "Trouver un moyen de transcrire le contenu textuel de l’exhibit (ZR)."@fr ,
+                                "Pour lier un contenu textuel à un exhibit dont celui-ci est le support, voir crm:P128_carries (DV)."@fr ,
                                 "Pour P2_has_type, utiliser aat:300211861 (Identification sign); voir skos:note de aat:300211861 dans ../vocab.ttl"@fr;
     crm:P2_has_type             aat:300211861 ;
-    crm:P67i_is_referred_to_by  <urn:uuid:c93e6840-ae2e-4e20-b181-ff0c7993d89c> ;
-    crm:P67i_is_referred_to_by  <urn:uuid:9e16b078-f3d8-40bf-80e3-44dc0ed16c99> ;
-    crm:P108i_was_produced_by   <urn:uuid:ea055aed-a5c0-435d-a7d2-3e9631434f53> .
+    crm:P67i_is_referred_to_by  <urn:uuid:c93e6840-ae2e-4e20-b181-ff0c7993d89c> ,
+                                <urn:uuid:9e16b078-f3d8-40bf-80e3-44dc0ed16c99> ;
+    crm:P108i_was_produced_by   <urn:uuid:ea055aed-a5c0-435d-a7d2-3e9631434f53> ;
+    crm:P128_carries            <urn:uuid:7bdf602c-4bbd-492f-b338-430abb759af8> ; # Nom de l’exposition
+    .
 
 <urn:uuid:c93e6840-ae2e-4e20-b181-ff0c7993d89c>
     rdf:type                      crm:E33_Linguistic_Object ;

--- a/data/exhibit/exhibit-0003.ttl
+++ b/data/exhibit/exhibit-0003.ttl
@@ -12,11 +12,14 @@ exhib:exhibit0003
     rdf:type                    crm:E22_Human-Made_Object ;
     rdfs:label                  "Crédits"@fr ;
     rdfs:comment                "Trouver un moyen de transcrire le contenu Exposition réalisée avec le concours de l’agence les readymade appartiennent à tout le monde ® (ZR)"@fr ,
-                                "Pour P2_has_type, utiliser aat:300213259 (Information sign); voir skos:note de aat:300213259 dans ../vocab.ttl"@fr;
+                                "Pour lier un contenu textuel à un exhibit dont celui-ci est le support, voir crm:P128_carries (DV)."@fr ,
+                                "Pour P2_has_type, utiliser aat:300213259 (Information sign); voir skos:note de aat:300213259 dans ../vocab.ttl"@fr ;
     crm:P2_has_type             aat:300213259 ;
     crm:P67i_is_referred_to_by  <urn:uuid:d5f56c31-f4ce-45d5-a3fd-e4f09aeea615> ,
                                 <urn:uuid:49bc2b2c-aebc-4a65-933d-3b6ef6c0286c> ;
-    crm:P108i_was_produced_by   <urn:uuid:ea055aed-a5c0-435d-a7d2-3e9631434f53> .
+    crm:P108i_was_produced_by   <urn:uuid:ea055aed-a5c0-435d-a7d2-3e9631434f53> ;
+    crm:P128_carries            <urn:uuid:30d9397a-c218-401a-96eb-0eb07298d616> ;
+    .
     
 <urn:uuid:d5f56c31-f4ce-45d5-a3fd-e4f09aeea615>
     rdf:type                      crm:E33_Linguistic_Object ;
@@ -29,3 +32,10 @@ exhib:exhibit0003
     crm:P190_has_symbolic_content "Crédits"@fr ;
     crm:P2_has_type               aat:300435416 ;
     crm:P72_has_language          aat:300388306 .
+
+<urn:uuid:30d9397a-c218-401a-96eb-0eb07298d616>
+    rdf:type                      crm:E33_Linguistic_Object ;
+    crm:P190_has_symbolic_content "Exposition réalisée avec le concours de l’agence les readymade appartiennent à tout le monde ®"@fr ;
+    crm:P2_has_type               aat:300026687 ; # Credit Line
+    crm:P72_has_language          aat:300388306 ;
+    .

--- a/data/vocab.ttl
+++ b/data/vocab.ttl
@@ -108,6 +108,7 @@ aat:300404670 a crm:E55_Type , skos:Concept ;
 aat:300418049 a crm:E55_Type , skos:Concept ;
   rdfs:label "Brief Text"@en .
 
+
 aat:300435416 a crm:E55_Type , skos:Concept ;
   rdfs:label "Description"@en ;
   crm:P2_has_type aat:300418049 .
@@ -124,6 +125,12 @@ aat:300435436 a crm:E55_Type , skos:Concept ;
   skos:scopeNote "A description of the production or creation of the object (source: Linked Art)"@en ;
   crm:P2_has_type aat:300418049 .
 
+
+aat:300026687 a crm:E55_Type , skos:Concept ;
+  rdfs:label "Credit Line"@en ;
+  skos:scopeNote "A short statement of who should be acknowledged for the object (source: Linked Art)"@en ;
+  crm:P2_has_type aat:300418049 ;
+  .
 
 aat:300435451 a crm:E55_Type , skos:Concept ;
   rdfs:label "Spatial Statement"@en ;


### PR DESCRIPTION
Besoin : "trouver un moyen de transcrire le contenu textuel de l’exhibit"

Solution : objet physique support d’un contenu textuel (objet linguistique).

Exemples :

- nom de l’exposition : l’objet physique situé dans l’espace est de type "identification sign" et le contenu textuel dont il est le support est un objet linguistique de type "Primary name"
- crédits de l’exposition : l’objet physique situé dans l’espace est de type "information sign" et le contenu textuel dont il est le support est un objet linguistique de type "Credit Line"

cc. @ZoeRenaudie 