### PR TITLE
Œuvre dans une collection

### DIFF
--- a/data/actor/actors.ttl
+++ b/data/actor/actors.ttl
@@ -13,6 +13,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     crm:P2_has_type aat:300312281 ;
     rdfs:label      "CAPC Musée d’art contemporain de Bordeaux"@fr .
 
+<http://viaf.org/viaf/280742300>
+    rdf:type        crm:E74_Group ;
+    crm:P2_has_type aat:300312281 ;
+    rdfs:label      "Musée des moulages (Strasbourg)"@fr ; # nom du musée d’après de la notice d’autorité VIAF.
+    .
+
 <http://vocab.getty.edu/ulan/500096019>
     rdf:type    crm:E21_Person ;
     rdfs:label  "Philippe Thomas"@fr .

--- a/data/exhibit/exhibit-0006.ttl
+++ b/data/exhibit/exhibit-0006.ttl
@@ -12,7 +12,9 @@ exhib:exhibit0006
     rdf:type                    crm:E22_Human-Made_Object ;
     rdfs:label                  "Buste de Platon"@fr ;
     rdfs:comment                "Ce buste est une copie d'un buste original, je ne sais pas comment l'intituler : vérifier ressource métier. (ZR)"@fr ,
-                                "Il faut aussi préciser qu'il est dans la Collection des moulages, Institut d’Archéologie classique de Strasbourg"@fr ;
+                                "Il faut aussi préciser qu'il est dans la Collection des moulages, Institut d’Archéologie classique de Strasbourg"@fr ,
+                                "Pour lier l’exhibit à une collection, utiliser la propriété la:member_of avec l’IRI de la collection comme valeur."@fr ;
+    la:member_of                exhib:set0001 ;
     crm:P2_has_type             aat:300133025 ,
                                 aat:300047090 ;
     crm:P1_is_identified_by     <urn:uuid:6b51598b-245d-4152-ae4d-6a55a5a81d4d> ;

--- a/data/exhibit/exhibit-0007.ttl
+++ b/data/exhibit/exhibit-0007.ttl
@@ -12,7 +12,9 @@ exhib:exhibit0007
     rdf:type                    crm:E22_Human-Made_Object ;
     rdfs:label                  "Buste de Simonide"@fr ;
     rdfs:comment                "Ce buste est une copie d'un buste original, je ne sais pas comment l'intituler : vérifier ressource métier. Dans l'exposition semble être nommé Simonide mais semblerait d'après d'autre sources que ce soit Eschyle (ZR)."@fr ,
-                                "Collection des moulages, Institut d’Archéologie classique de Strasbourg (ZR)"@fr ;
+                                "Collection des moulages, Institut d’Archéologie classique de Strasbourg (ZR)"@fr ,
+                                "Pour lier l’exhibit à une collection, utiliser la propriété member_of avec l’IRI de la collection comme valeur."@fr ;
+    la:member_of                exhib:set0001 ; # collection de moulages
     crm:P2_has_type             aat:300133025 ,
                                 aat:300047090 ;
     crm:P1_is_identified_by     <urn:uuid:37a9f599-0d38-40f6-a0eb-bf5d0e9bca77> ;

--- a/data/set/0001.ttl
+++ b/data/set/0001.ttl
@@ -1,0 +1,39 @@
+PREFIX bot:     <https://w3id.org/bot#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX display: <https://w3id.org/display#>
+PREFIX exhib:   <https://ouvroir.umontreal.ca/data/>
+PREFIX la:      <https://linked.art/ns/terms/>
+PREFIX crm:     <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX aat:     <http://vocab.getty.edu/aat/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+########################################################
+# Collection de moulages
+# Institut d’archéologie classique de Strasbourg
+# Musée des moulages, Strasbourg
+# <http://viaf.org/viaf/280742300>
+# voir https://linked.art/model/collection/
+########################################################
+
+exhib:set0001
+    rdf:type                la:Set ;
+    rdfs:label              "Collection de moulages (IAC Strasbourg)"@fr ;
+    crm:P2_has_type         aat:300025976 ; # Collection
+    crm:P1_is_identified_by <urn:uuid:2b1d2c57-33ce-4e21-82ce-293988e1d2e8> ;
+    crm:P16i_was_used_for   <urn:uuid:2f691081-9573-4660-b359-bb2a10dbd81b> ;
+    .
+
+<urn:uuid:2b1d2c57-33ce-4e21-82ce-293988e1d2e8>
+    rdf:type                      crm:E33_E41_Linguistic_Appellation ;
+    crm:P190_has_symbolic_content "Collection de moulages (Musée des moulages, Strasbourg)"@fr ;
+    crm:P2_has_type               aat:300404670 ;
+    crm:P72_has_language          aat:300388306 ;
+    .
+
+<urn:uuid:2f691081-9573-4660-b359-bb2a10dbd81b>
+    rdf:type                crm:E7_Activity ;
+    rdfs:label              "Activité curatoriale (Collection de moulages, Musée des moulages, Strasbourg)"@fr ;
+    crm:P2_has_type         aat:300054277 ;
+    crm:P14_carried_out_by  <http://viaf.org/viaf/280742300> ;
+    .


### PR DESCRIPTION
Besoin : indiquer la collection à laquelle appartient une œuvre dans son dans son institution d’origine.

Solution : utiliser la classe `la:Set` appliquée aux collections d’objets

- la collection (une instance de `la:Set`) utilise la propriété `crm:P2_has_type` avec la valeur `aat:300025976` (collection)
- l’œuvre est membre (`la:member_of`) de la collection

Le lien entre la collection et l’acteur peut passer par une activité de type `aat:300054277` (curation), comme dans le présent commit, ou par un événement de création (`crm:E65_Creation`).

Remarque : la classe `la:Set` est une ressource externe à CIDOC CRM, permettant d’exprimer tout type d’agrégation d’entités en utilisant le même patron ; c’est pourquoi `crm:E78_Curated_Holding`, plus contraignant sémantiquement, n’est pas utilisé ; il s’agit d’une approche qui s’inscrit dans le cadre des principes LOUD.

Source : https://linked.art/model/collection/

Pour effectuer le suivi de la provenance, voir https://linked.art/model/provenance/

cc. @ZoeRenaudie 